### PR TITLE
Hide browser selection box on burger button

### DIFF
--- a/app/scss/_burger.scss
+++ b/app/scss/_burger.scss
@@ -16,6 +16,10 @@
     position: relative;
     transition: $b-transition;
     width: $b-height;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
     z-index: 999;
   }
 


### PR DESCRIPTION
Hey Matthew,

When a user clicks the `.burger` element in rapid succession or accidentally highlights the element the browser creates an ugly blue selection box on top of the button.

See screenshot: https://www.dropbox.com/s/tnp47t9uvn50vwv/Screen%20Shot%202015-04-06%20at%2011.10.48%20AM.png?dl=0

My fix is well documented and will not cause any adverse effects on click or tap. 

CSS-Tricks Documentation: https://css-tricks.com/almanac/properties/u/user-select/
