### PR TITLE
Update burger.scss

### DIFF
--- a/src/sass/burger.scss
+++ b/src/sass/burger.scss
@@ -64,7 +64,8 @@ body {
   &:after {
     background: color(primary);
     content: '';
-    height: 100%;
+    height: 110%;
+    visibility: hidden;
     left: 0;
     opacity: 0;
     overflow: hidden;


### PR DESCRIPTION
Extra height offset (10%) to prevent "peeking" effect when the address bar hides in android devices.
Added `visibility:hidden;` to  body:after.