### PR TITLE
Make text transition smooth

### DIFF
--- a/src/sass/burger.scss
+++ b/src/sass/burger.scss
@@ -37,7 +37,7 @@ $b-pad-top: ($b-height / 2 - $b-bun-width-half); //Vertically centers bun in men
 @keyframes slideInLeft {
   0% {
     transform: translate3d(-250px, 0, 0);
-    visibility: visible;
+    opacity: 1;
   }
 
   100% {
@@ -52,7 +52,7 @@ $b-pad-top: ($b-height / 2 - $b-bun-width-half); //Vertically centers bun in men
 
   100% {
     transform: translate3d(-250px, 0, 0);
-    visibility: hidden;
+    opacity: 0;
   }
 }
 
@@ -64,15 +64,13 @@ body {
   &:after {
     background: color(primary);
     content: '';
-    height: 110%;
-    visibility: hidden;
+    height: 100%;
     left: 0;
     opacity: 0;
     overflow: hidden;
     padding: 0;
     position: absolute;
     top: 0;
-    visibility: hidden;
     transition: $b-transition;
     width: 100%;
   }
@@ -92,7 +90,8 @@ body {
   z-index: 11;
 
   &:not(.open) {
-    visibility: hidden;
+    opacity: 0;
+    transition: $b-transition;
   }
 
   li {
@@ -114,7 +113,7 @@ body {
   }
 
   &.open {
-    visibility: visible;
+    opacity: 1;
 
     li {
       animation-duration: $b-trans-speed;


### PR DESCRIPTION
The opened menu's text normally pops in abruptly. This makes it fade in and out like the rest of the menu does